### PR TITLE
FFTsInSingleDataset

### DIFF
--- a/Source/Data/Time/KTEggHeader.cc
+++ b/Source/Data/Time/KTEggHeader.cc
@@ -8,6 +8,7 @@
 #include "KTEggHeader.hh"
 
 #include "KTConstants.hh"
+#include "KTLogger.hh"
 
 #include <ostream>
 
@@ -16,6 +17,8 @@ using std::vector;
 namespace Katydid
 {
     const std::string KTEggHeader::sName("egg-header");
+
+    KTLOGGER(eggheaderlog, "KTEggHeader");
 
     KTChannelHeader::KTChannelHeader() :
             fNumber(0),
@@ -148,6 +151,7 @@ namespace Katydid
         {
             fChannelHeaders[iComponent] = NULL;
         }
+        KTINFO(eggheaderlog,"(KTEggHeader::SetNChannels) Set Number of Channel Headers to " << num);
         return *this;
     }
 

--- a/Source/IO/KTHDF5TypeWriterTransform.hh
+++ b/Source/IO/KTHDF5TypeWriterTransform.hh
@@ -51,7 +51,6 @@ namespace Katydid {
         void WriteFrequencySpectrumDataFFTWPhase(KTDataPtr data);
         void WriteFrequencySpectrumDataPolarPower(KTDataPtr data);
         void WriteFrequencySpectrumDataFFTWPower(KTDataPtr data);
-
         void WriteFrequencySpectrumDataPolarMagnitudeDistribution(KTDataPtr data);
         void WriteFrequencySpectrumDataFFTWMagnitudeDistribution(KTDataPtr data);
         void WriteFrequencySpectrumDataPolarPowerDistribution(KTDataPtr data);
@@ -62,7 +61,6 @@ namespace Katydid {
          */
         void WritePowerSpectrum(KTDataPtr data);
         void WritePowerSpectralDensity(KTDataPtr data);
-
         void WritePowerSpectrumDistribution(KTDataPtr data);
         void WritePowerSpectralDensityDistribution(KTDataPtr data);
 
@@ -86,73 +84,35 @@ namespace Katydid {
      * Internal data members
      */
     private:
-    	typedef boost::multi_array<double, 2> fft_buffer;
-    	H5::DataSet* CreatePolarFFTDSet(const std::string& name);
-    	H5::DataSet* CreatePolarPowerDSet(const std::string& name);
-    	H5::DataSet* CreateComplexFFTDSet(const std::string& name);
-    	H5::DataSet* CreateComplexPowerDSet(const std::string& name);
-        H5::DataSet* CreatePowerSpecDSet(const std::string& name);
-        H5::DataSet* CreatePSDDSet(const std::string& name);
-        H5::DataSet* CreateFFTWFreqArrayDSet(const std::string& name);
-        H5::DataSet* CreatePolarFreqArrayDSet(const std::string& name);
-    	H5::DataSet* CreateDSet(const std::string& name, 
+    	typedef boost::multi_array<double, 4> fft_buffer;
+        typedef boost::multi_array<double, 1> freq_buffer;
+    	void PrepareHDF5File(const std::string& SlotName);
+    	H5::DataSet* CreateDSet(const std::string& name,
     							const H5::Group* grp,
     							const H5::DataSpace& ds);
 
-    	void CreateDataspaces();
+    	unsigned fNChannels;
+        unsigned fNComponents;
+        unsigned fNumberOfSlices;
+        unsigned fSliceSize;
 
-    	unsigned fNComponents;
-    	unsigned fSliceSize;
-
-    	H5::Group* fFFTGroup;
-    	H5::Group* fPowerGroup;
-
-    	/*
-    	 * power FS and PS
-    	 */
-    	unsigned fPolarFFTSize;
-    	fft_buffer* fPolarFFTBuffer;
-    	H5::DataSpace* fPolarFFTDSpace;
-
-    	unsigned fPolarPwrSize;
-    	fft_buffer* fPolarPwrBuffer;
-    	H5::DataSpace* fPolarPwrDSpace;
-
-    	/* 
-    	 * complex (FFTW) FS and PS
-    	 */
-    	unsigned fCmplxFFTSize;
-    	fft_buffer* fCmplxFFTBuffer;
-    	H5::DataSpace* fCmplxFFTDSpace;
-
-    	unsigned fCmplxPwrSize;
-    	fft_buffer* fCmplxPwrBuffer;
-    	H5::DataSpace* fCmplxPwrDSpace;
-
-        /*
-         * Power spectrum and Power spectral density
-         */
-        unsigned fPwrSpecSize;
-        fft_buffer* fPwrSpecBuffer;
-        H5::DataSpace* fPwrSpecDSpace;
-
-        unsigned fPSDSize;
-        fft_buffer* fPSDBuffer;
-        H5::DataSpace* fPSDDSpace;
-
-        /*
-         * Frequency Arrays (the "X-Axis" of the FFT)
-         */
-         fft_buffer* fPolarFFTFreqArrayBuffer;
-         fft_buffer* fCmplxFFTFreqArrayBuffer;
-        H5::DataSpace* fFFTWFreqArrayDSpace;
-        H5::DataSpace* fPolarFreqArrayDSpace;
-
-
-        /* 
-         * Group for spectral data
-         */
         H5::Group* fSpectraGroup;
+    	H5::Group* fFFTGroup;
+        H5::DataSet* fDSet;
+        H5::DataSet* fDSet_FreqArray;
+
+    	unsigned fFFTSize;
+    	fft_buffer* fFFTBuffer;
+    	H5::DataSpace* fFFTDataSpace;
+
+        // Frequency Arrays (the "X-Axis" of the FFT)
+        freq_buffer* fFFTFreqArrayBuffer;
+        H5::DataSpace* fFFTFreqArrayDataSpace;
+
+        // Dataspace dimensions
+        hsize_t ds_dims[4];
+        hsize_t ds_maxdims[4];
+
     };
 }
 

--- a/Source/IO/KTHDF5TypeWriterTransform.hh
+++ b/Source/IO/KTHDF5TypeWriterTransform.hh
@@ -38,6 +38,7 @@ namespace Katydid {
      */
     public:
     	void ProcessEggHeader();
+        void PrepareHDF5File();
         MEMBERVARIABLE(bool, FirstSliceHasBeenWritten);
         MEMBERVARIABLE(bool, CompressFFTFlag);
 
@@ -86,7 +87,6 @@ namespace Katydid {
     private:
     	typedef boost::multi_array<double, 4> fft_buffer;
         typedef boost::multi_array<double, 1> freq_buffer;
-    	void PrepareHDF5File(const std::string& SlotName);
     	H5::DataSet* CreateDSet(const std::string& name,
     							const H5::Group* grp,
     							const H5::DataSpace& ds);
@@ -95,6 +95,8 @@ namespace Katydid {
         unsigned fNComponents;
         unsigned fNumberOfSlices;
         unsigned fSliceSize;
+        unsigned fSliceNumber;
+        std::string fSpectrumName;
 
         H5::Group* fSpectraGroup;
     	H5::Group* fFFTGroup;

--- a/Source/IO/KTHDF5Writer.cc
+++ b/Source/IO/KTHDF5Writer.cc
@@ -111,7 +111,12 @@ namespace Katydid
 
         // copy the egg header.
         this->fHeader = header;
+        this->fHeader.SetChannelHeader(header.GetChannelHeader(0),0);
+        KTDEBUG(publog, "Header Number of Channels: " << header.GetNChannels());
         this->fHeaderParsed = true;
+        //KTDEBUG(publog, "header.GetChannelHeader(0): - " << header.GetChannelHeader(0));
+        //KTDEBUG(publog, "this->fHeader.GetChannelHeader(0): - " << this->fHeader.GetChannelHeader(0));
+
 
         H5::Group* header_grp = this->AddGroup("/metadata");
        
@@ -152,9 +157,9 @@ namespace Katydid
             token = name.substr(0, pos);
             group_name_builder << token;
             group_name_builder >> group_name;
-            KTINFO(group_name);
             grp = *(this->AddGroup(group_name));
             name.erase(0, pos + delimiter.length());
+            KTINFO(group_name + delimiter + name);
         }
         H5::DataSpace dspace(H5S_SCALAR);
         H5::DSetCreatPropList plist;

--- a/Source/Time/KTEggProcessor.cc
+++ b/Source/Time/KTEggProcessor.cc
@@ -143,8 +143,9 @@ namespace Katydid
         KTPROG(egglog, "Proceeding with slice processing");
 
 
+        KTDEBUG(egglog, "(KTEggProcessor::ProcessEgg 2) Header Number of Channels: " << header.GetNChannels());
 
-        if (fNSlices == 0) UnlimitedLoop(reader);
+        if (fNSlices == 0) UnlimitedLoop(reader, header);
         else LimitedLoop(reader);
 
         fEggDoneSignal();
@@ -165,7 +166,7 @@ namespace Katydid
         return true;
     }
 
-    void KTEggProcessor::UnlimitedLoop(KTEggReader* reader)
+    void KTEggProcessor::UnlimitedLoop(KTEggReader* reader, KTEggHeader& header)
     {
         unsigned iSlice = 0, iProgress = 0;
         KTDataPtr data, nextData;
@@ -214,6 +215,7 @@ namespace Katydid
             if (! nextSliceIsValid) break;
             data = nextData;
         }
+        KTDEBUG(egglog, "(KTRSAMatReader::HatchNextSlice) Header Number of Channels: " << header.GetNChannels());
         return;
     }
 

--- a/Source/Time/KTEggProcessor.hh
+++ b/Source/Time/KTEggProcessor.hh
@@ -14,6 +14,7 @@
 #include "KTData.hh"
 #include "KTEggReader.hh"
 #include "KTSlot.hh"
+#include "KTEggHeader.hh"
 
 
 namespace Katydid
@@ -110,7 +111,7 @@ namespace Katydid
             void NormalizeData(KTDataPtr& data);
 
         private:
-            void UnlimitedLoop(KTEggReader* reader);
+            void UnlimitedLoop(KTEggReader* reader, KTEggHeader& header);
             void LimitedLoop(KTEggReader* reader);
 
 

--- a/Source/Time/KTRSAMatReader.cc
+++ b/Source/Time/KTRSAMatReader.cc
@@ -455,6 +455,8 @@ namespace Katydid
 
         KTDEBUG(eggreadlog, sliceHeader << "\nNote: some fields may not be filled in correctly yet");
 
+        KTDEBUG(eggreadlog, "(KTRSAMatReader::HatchNextSlice) Header Number of Channels: " << fHeader.GetNChannels());
+
         return newData;
     }
 

--- a/Source/Transform/KTForwardFFTW.cc
+++ b/Source/Transform/KTForwardFFTW.cc
@@ -198,6 +198,7 @@ namespace Katydid
 
     bool KTForwardFFTW::InitializeWithHeader(KTEggHeader& header)
     {
+        KTDEBUG(fftwlog, "(FFT) Header Number of Channels: " << header.GetNChannels());
         if (header.GetTSDataType() == KTEggHeader::kReal)
         {
             return InitializeForRealTDD(header.GetChannelHeader(0)->GetSliceSize());
@@ -208,6 +209,7 @@ namespace Katydid
             else fComplexAsIQ = false;
             return InitializeForComplexTDD(header.GetChannelHeader(0)->GetSliceSize());
         }
+
     }
 
     bool KTForwardFFTW::TransformRealData(KTTimeSeriesData& tsData)


### PR DESCRIPTION
Modified the HDF5 FFT writer (KTHDF5TypeWriterTransform) to save all FFTs or Power Spectra from an Egg or MAT file into a single HDF5 dataset, instead of saving one dataset per slice.  We also streamlined the writer processor - now it creates a single buffer and dataset with the required dimensions, instead of creating several buffers and datasets for each possible output, and then choosing which one to use. We also fixed references to Channel Headers, which were incorrect and causing the HDF5 writer to crash.