### PR TITLE
Feature/h5update

### DIFF
--- a/Source/Data/EventAnalysis/KTPowerFitData.hh
+++ b/Source/Data/EventAnalysis/KTPowerFitData.hh
@@ -70,6 +70,8 @@ namespace Katydid
                 double fCentralPowerRatio; // Ratio of average power within 3 sigma of the central peak to average power greater than 3 sigma from the central peak
 
                 double fTrackIntercept; // just so that we don't lose this info, since it is subtracted away
+
+                unsigned fTrackID; // TrackID from KTProcessedTrackData
             };
 
         public:
@@ -153,6 +155,9 @@ namespace Katydid
 
             double GetTrackIntercept( unsigned component = 0 ) const;
             void SetTrackIntercept( double alpha, unsigned component = 0 );
+
+            unsigned GetTrackID( unsigned component = 0 ) const;
+            void SetTrackID(unsigned trackID, unsigned component = 0);
 
         private:
             std::vector< PerComponentData > fComponentData;
@@ -427,6 +432,18 @@ namespace Katydid
         fComponentData[component].fTrackIntercept = alpha;
         return;
     }
+
+    inline unsigned KTPowerFitData::GetTrackID(unsigned component) const
+    {
+        return fComponentData[component].fTrackID;
+    }
+
+    inline void KTPowerFitData::SetTrackID(unsigned trackID, unsigned component)
+    {
+        fComponentData[component].fTrackID = trackID;
+        return;
+    }
+
 
 } /* namespace Katydid */
 #endif /* KTPOWERFITDATA_HH */

--- a/Source/EventAnalysis/KTLinearDensityProbeFit.cc
+++ b/Source/EventAnalysis/KTLinearDensityProbeFit.cc
@@ -680,8 +680,11 @@ namespace Katydid
         newData.SetRMSAwayFromCentral( nonCentralRMS );
         newData.SetCentralPowerRatio( centralMean / nonCentralMean );
 
-        // Lastly we copy the track intercept to newData
+        // We copy the track intercept to newData
         newData.SetTrackIntercept( data.GetIntercept() );
+
+        // Lastly we copy the track ID to newData
+        newData.SetTrackID( data.GetTrackID() );
 
         KTINFO(evlog, "Finished classifier calculations. Power fit data is done!");
 

--- a/Source/IO/HDF5Writer/KTHDF5TypeWriterEventAnalysis.cc
+++ b/Source/IO/HDF5Writer/KTHDF5TypeWriterEventAnalysis.cc
@@ -292,6 +292,7 @@ namespace Katydid
         powerFit.MaximumCentral = pfData.GetMaximumCentral();
         powerFit.RMSAwayFromCentral = pfData.GetRMSAwayFromCentral();
         powerFit.CentralPowerRatio = pfData.GetCentralPowerRatio();
+        powerFit.TrackID = pfData.GetTrackID();
 
         (this->fPFDataBuffer).push_back(powerFit);
 

--- a/Source/IO/HDF5Writer/KTHDF5TypeWriterEventAnalysis.cc
+++ b/Source/IO/HDF5Writer/KTHDF5TypeWriterEventAnalysis.cc
@@ -73,6 +73,7 @@ namespace Katydid {
         fWriter->RegisterSlot("multi-track-event", this, &KTHDF5TypeWriterEventAnalysis::WriteMultiTrackEvent);
         fWriter->RegisterSlot("final-write-events", this, &KTHDF5TypeWriterEventAnalysis::WriteMTEBuffer);
         fWriter->RegisterSlot("power-fit", this, &KTHDF5TypeWriterEventAnalysis::WritePowerFitData);
+        fWriter->RegisterSlot("final-write-pf", this, &KTHDF5TypeWriterEventAnalysis::WritePFBuffer);
         return;
     }
 

--- a/Source/IO/HDF5Writer/KTHDF5TypeWriterEventAnalysis.cc
+++ b/Source/IO/HDF5Writer/KTHDF5TypeWriterEventAnalysis.cc
@@ -24,40 +24,45 @@ namespace Katydid
 
     static Nymph::KTTIRegistrar<KTHDF5TypeWriter, KTHDF5TypeWriterEventAnalysis> sH5CNDrg;
     KTHDF5TypeWriterEventAnalysis::KTHDF5TypeWriterEventAnalysis() :
-        KTHDF5TypeWriter(),
-        fMTEDataBuffer(),
-        fMTETracksDataBuffer(),
-        fPTDataBuffer(),
-        fPFDataBuffer(),
-        fFlushMTEIdx(0),
-        fFlushPTIdx(0),
-        fFlushPFIdx(0) {
-            /*
-             * First we build the appropriate compound datatype for MTE events
-             */
-            this->fMTEType = new H5::CompType(MTESize);
-            // Insert fields into the type
-            for (int f = 0; f < MTENFields; f++) {
-                this->fMTEType->insertMember(
-                    MTEFieldNames[f],
-                    MTEFieldOffsets[f],
-                    MTEFieldTypes[f]);
-            }
-            this->fPTType = new H5::CompType(PTSize);
-            for (int f = 0; f < PTNFields; f++) {
-                this->fPTType->insertMember(
-                    PTFieldNames[f],
-                    PTFieldOffsets[f],
-                    PTFieldTypes[f]);
-            }
-            this->fPFType = new H5::CompType(PFSize);
-            for (int f = 0; f < PFNFields; f++) {
-                this->fPFType->insertMember(
-                    PFFieldNames[f],
-                    PFFieldOffsets[f],
-                    PFFieldTypes[f]);
-            }
+            KTHDF5TypeWriter(),
+            fMTEDataBuffer(),
+            fMTETracksDataBuffer(),
+            fPTDataBuffer(),
+            fPFDataBuffer(),
+            fFlushMTEIdx(0),
+            fFlushPTIdx(0),
+            fFlushPFIdx(0) 
+
+    {
+        /*
+         * First we build the appropriate compound datatype for MTE events
+         */
+        this->fMTEType = new H5::CompType(MTESize);
+        // Insert fields into the type
+        for (int f = 0; f < MTENFields; f++) 
+        {
+            this->fMTEType->insertMember(
+                MTEFieldNames[f],
+                MTEFieldOffsets[f],
+                MTEFieldTypes[f]);
         }
+        this->fPTType = new H5::CompType(PTSize);
+        for (int f = 0; f < PTNFields; f++) 
+        {
+            this->fPTType->insertMember(
+                PTFieldNames[f],
+                PTFieldOffsets[f],
+                PTFieldTypes[f]);
+        }
+        this->fPFType = new H5::CompType(PFSize);
+        for (int f = 0; f < PFNFields; f++) 
+        {
+            this->fPFType->insertMember(
+                PFFieldNames[f],
+                PFFieldOffsets[f],
+                PFFieldTypes[f]);
+        }
+    }
 
     KTHDF5TypeWriterEventAnalysis::~KTHDF5TypeWriterEventAnalysis()
     {
@@ -66,7 +71,8 @@ namespace Katydid
         if(fPFType) delete fPFType;
     }
 
-    void KTHDF5TypeWriterEventAnalysis::RegisterSlots() {
+    void KTHDF5TypeWriterEventAnalysis::RegisterSlots() 
+    {
         //fWriter->RegisterSlot("frequency-candidates", this, &KTHDF5TypeWriterEventAnalysis::WriteFrequencyCandidates);
         //fWriter->RegisterSlot("waterfall-candidates", this, &KTHDF5TypeWriterEventAnalysis::WriteWaterfallCandidate);
         //fWriter->RegisterSlot("sparse-waterfall-candidates", this, &KTHDF5TypeWriterEventAnalysis::WriteSparseWaterfallCandidate);
@@ -277,7 +283,8 @@ namespace Katydid
         fFlushPTIdx++;
     }
 
-    void KTHDF5TypeWriterEventAnalysis::WritePowerFitData(Nymph::KTDataPtr data) {
+    void KTHDF5TypeWriterEventAnalysis::WritePowerFitData(Nymph::KTDataPtr data) 
+    {
         KTDEBUG(publog, "Processing Power Fit Data");
         KTPowerFitData& pfData = data->Of< KTPowerFitData >();
 
@@ -300,7 +307,8 @@ namespace Katydid
         return;
     }
 
-    void KTHDF5TypeWriterEventAnalysis::WritePFBuffer() {
+    void KTHDF5TypeWriterEventAnalysis::WritePFBuffer() 
+    {
         KTDEBUG(publog, "Writing PF Data Buffer");
 
         hsize_t* dims = new hsize_t(this->fPFDataBuffer.size());

--- a/Source/IO/HDF5Writer/KTHDF5TypeWriterEventAnalysis.hh
+++ b/Source/IO/HDF5Writer/KTHDF5TypeWriterEventAnalysis.hh
@@ -266,6 +266,60 @@ namespace Katydid {
         H5::PredType::NATIVE_DOUBLE
     };
 
+    // Now the same for KTPowerFitData
+
+    typedef struct {
+        double Average;
+        double RMS;
+        double Skewness;
+        double Kurtosis;
+        double NormCentral;
+        double MeanCentral;
+        double SigmaCentral;
+        double MaximumCentral;
+        double RMSAwayFromCentral;
+        double CentralPowerRatio;
+    } PFData;
+
+    const size_t PFNFields = 10;
+    size_t PFSize = sizeof(PFData);
+    const char* PFFieldNames[PFNFields] = {
+        "Average",
+        "RMS",
+        "Skewness",
+        "Kurtosis",
+        "NormCentral",
+        "MeanCentral",
+        "SigmaCentral",
+        "MaximumCentral",
+        "RMSAwayFromCentral",
+        "CentralPowerRatio"
+    };
+    size_t PFFieldOffsets[PFNFields] = {
+        HOFFSET(PFData, Average),
+        HOFFSET(PFData, RMS),
+        HOFFSET(PFData, Skewness),
+        HOFFSET(PFData, Kurtosis),
+        HOFFSET(PFData, NormCentral),
+        HOFFSET(PFData, MeanCentral),
+        HOFFSET(PFData, SigmaCentral),
+        HOFFSET(PFData, MaximumCentral),
+        HOFFSET(PFData, RMSAwayFromCentral),
+        HOFFSET(PFData, CentralPowerRatio)
+    };
+    H5::PredType PFFieldTypes[PFNFields] = {
+        H5::PredType::NATIVE_DOUBLE,
+        H5::PredType::NATIVE_DOUBLE,
+        H5::PredType::NATIVE_DOUBLE,
+        H5::PredType::NATIVE_DOUBLE,
+        H5::PredType::NATIVE_DOUBLE,
+        H5::PredType::NATIVE_DOUBLE,
+        H5::PredType::NATIVE_DOUBLE,
+        H5::PredType::NATIVE_DOUBLE,
+        H5::PredType::NATIVE_DOUBLE,
+        H5::PredType::NATIVE_DOUBLE
+    };
+
     class KTHDF5TypeWriterEventAnalysis: public KTHDF5TypeWriter {
         /*
         * The usual constructor/destructor/slot boilerplate
@@ -284,8 +338,10 @@ namespace Katydid {
         void WriteSparseWaterfallCandidate(Nymph::KTDataPtr data);
         void WriteProcessedTrack(Nymph::KTDataPtr data);
         void WriteMultiTrackEvent(Nymph::KTDataPtr data);
+        void WritePowerFitData(Nymph::KTDataPtr data);
         void WriteMTEBuffer();
         void WritePTBuffer();
+        void WritePFBuffer();
 
     private:
         std::vector<MTEData> fMTEDataBuffer;
@@ -293,9 +349,12 @@ namespace Katydid {
         std::vector<PTData> fMTETracksDataBuffer;
         std::vector<PTData> fPTDataBuffer;
         H5::CompType* fPTType;
+        std::vector<PFData> fPFDataBuffer;
+        H5::CompType* fPFType;
 
         unsigned fFlushMTEIdx;
         unsigned fFlushPTIdx;
+        unsigned fFlushPFIdx;
     };
 };
 

--- a/Source/IO/HDF5Writer/KTHDF5TypeWriterEventAnalysis.hh
+++ b/Source/IO/HDF5Writer/KTHDF5TypeWriterEventAnalysis.hh
@@ -289,9 +289,10 @@ namespace Katydid
         double MaximumCentral;
         double RMSAwayFromCentral;
         double CentralPowerRatio;
+        unsigned TrackID;
     } PFData;
 
-    const size_t PFNFields = 10;
+    const size_t PFNFields = 11;
     size_t PFSize = sizeof(PFData);
     const char* PFFieldNames[PFNFields] = {
         "Average",
@@ -303,7 +304,8 @@ namespace Katydid
         "SigmaCentral",
         "MaximumCentral",
         "RMSAwayFromCentral",
-        "CentralPowerRatio"
+        "CentralPowerRatio",
+        "TrackID"
     };
     size_t PFFieldOffsets[PFNFields] = {
         HOFFSET(PFData, Average),
@@ -315,7 +317,8 @@ namespace Katydid
         HOFFSET(PFData, SigmaCentral),
         HOFFSET(PFData, MaximumCentral),
         HOFFSET(PFData, RMSAwayFromCentral),
-        HOFFSET(PFData, CentralPowerRatio)
+        HOFFSET(PFData, CentralPowerRatio),
+        HOFFSET(PFData, TrackID)
     };
     H5::PredType PFFieldTypes[PFNFields] = {
         H5::PredType::NATIVE_DOUBLE,
@@ -327,7 +330,8 @@ namespace Katydid
         H5::PredType::NATIVE_DOUBLE,
         H5::PredType::NATIVE_DOUBLE,
         H5::PredType::NATIVE_DOUBLE,
-        H5::PredType::NATIVE_DOUBLE
+        H5::PredType::NATIVE_DOUBLE,
+        H5::PredType::NATIVE_UINT
     };
 
     class KTHDF5TypeWriterEventAnalysis: public KTHDF5TypeWriter

--- a/Source/IO/HDF5Writer/KTHDF5TypeWriterEventAnalysis.hh
+++ b/Source/IO/HDF5Writer/KTHDF5TypeWriterEventAnalysis.hh
@@ -278,7 +278,8 @@ namespace Katydid
 
     // Now the same for KTPowerFitData
 
-    typedef struct {
+    typedef struct 
+    {
         double Average;
         double RMS;
         double Skewness;
@@ -294,7 +295,8 @@ namespace Katydid
 
     const size_t PFNFields = 11;
     size_t PFSize = sizeof(PFData);
-    const char* PFFieldNames[PFNFields] = {
+    const char* PFFieldNames[PFNFields] = 
+    {
         "Average",
         "RMS",
         "Skewness",
@@ -307,7 +309,8 @@ namespace Katydid
         "CentralPowerRatio",
         "TrackID"
     };
-    size_t PFFieldOffsets[PFNFields] = {
+    size_t PFFieldOffsets[PFNFields] = 
+    {
         HOFFSET(PFData, Average),
         HOFFSET(PFData, RMS),
         HOFFSET(PFData, Skewness),
@@ -320,7 +323,8 @@ namespace Katydid
         HOFFSET(PFData, CentralPowerRatio),
         HOFFSET(PFData, TrackID)
     };
-    H5::PredType PFFieldTypes[PFNFields] = {
+    H5::PredType PFFieldTypes[PFNFields] = 
+    {
         H5::PredType::NATIVE_DOUBLE,
         H5::PredType::NATIVE_DOUBLE,
         H5::PredType::NATIVE_DOUBLE,


### PR DESCRIPTION
- KTPowerFitData class now has TrackID variable from KTProcessedTrackData
- HDF5 Writer has slot for KTPowerFitData

i.e. the results of power-fit can now be written out to an hdf5 file, extending the root writer-only option.

Tested and working.