### PR TITLE
removed the power calculation from UpdateTrackProperties to Trimming.

### DIFF
--- a/Source/Data/SpectrumAnalysis/KTSeqLine.cc
+++ b/Source/Data/SpectrumAnalysis/KTSeqLine.cc
@@ -76,7 +76,7 @@ namespace Katydid
     }
 
 
-    /*inline void LineRef::CalculateNewSlope()
+    /*inline void LineRef::CalculateUnweightedSlope()
     {
         fSumX = 0.0;
         fSumY = 0.0;
@@ -171,6 +171,11 @@ namespace Katydid
         fStartFrequency = fLinePoints.front().fPointFreq;
         fStartTimeInAcq = fLinePoints.front().fTimeInAcq;
 
+        for(std::vector<LinePoint>::iterator pointIt = fLinePoints.begin(); pointIt != fLinePoints.end(); ++pointIt)
+        {
+            fAmplitudeSum += pointIt->fAmplitude;
+        }
+
         this->UpdateLineProperties();
         //this->CalculateSlope();
     }
@@ -191,7 +196,7 @@ namespace Katydid
         fEndTimeInRunC = fLinePoints.back().fTimeInRunC;
         fEndTimeInAcq = fLinePoints.back().fTimeInAcq;
         fEndFrequency = fLinePoints.back().fPointFreq;
-        fAmplitudeSum += fLinePoints.back().fAmplitude;
+        //fAmplitudeSum += fLinePoints.back().fAmplitude;
     }
 } /* namespace Katydid */
 

--- a/Source/SpectrumAnalysis/KTSequentialTrackFinder.cc
+++ b/Source/SpectrumAnalysis/KTSequentialTrackFinder.cc
@@ -291,6 +291,7 @@ namespace Katydid
                              if (lineIt->fNPoints >= fMinPoints and lineIt->fSlope > fMinSlope)
                              {
                                  KTINFO(stflog, "Found track candidate");
+                                 (this->*fCalcSlope)(*lineIt);
                                  this->EmitPreCandidate(*lineIt);
                              }
                          }


### PR DESCRIPTION
fAmplitudeSum of a KTSeqLine is now only calculated after the line trimming.
No other method in the sequential track finder uses this variable (only the weighted running average slope method would but it is commented because I never managed to get it working).

I reprocessed run 3004 with this update and the output events did not change which is what I expected.