### PR TITLE
Remove options forcing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ option (Katydid_USE_DLIB "Flag to optionally use DLIB library, required for clas
 
 set_option( Scarab_BUILD_CODEC_YAML TRUE )
 set_option( Nymph_BUILD_NYMPH_EXE FALSE )
-#set_option( Cicada_ENABLE_KATYDID_NAMESPACE FALSE )
-#set_option( Cicada_ADD_CICADA_PY FALSE )
+set_option( Cicada_ENABLE_KATYDID_NAMESPACE FALSE )
+set_option( Cicada_ADD_CICADA_PY TRUE )
 set_option( Cicada_ENABLE_EXECUTABLES FALSE )
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,8 +44,8 @@ option (Katydid_USE_DLIB "Flag to optionally use DLIB library, required for clas
 
 set_option( Scarab_BUILD_CODEC_YAML TRUE )
 set_option( Nymph_BUILD_NYMPH_EXE FALSE )
-set_option( Cicada_ENABLE_KATYDID_NAMESPACE FALSE )
-set_option( Cicada_ADD_CICADA_PY FALSE )
+#set_option( Cicada_ENABLE_KATYDID_NAMESPACE FALSE )
+#set_option( Cicada_ADD_CICADA_PY FALSE )
 set_option( Cicada_ENABLE_EXECUTABLES FALSE )
 
 


### PR DESCRIPTION
When set like this, it is impossible to change the variables using ccmake or the `-D` options with cmake.
Although some options are maybe not necessary, we should be able to set some to the desired value.