### PR TITLE
Feature/channel summation

### DIFF
--- a/Examples/ConfigFiles/ChannelAggregatorConfig.yaml
+++ b/Examples/ConfigFiles/ChannelAggregatorConfig.yaml
@@ -64,6 +64,7 @@ ch-sum:
     grid-size: 5
     active-radius: 0.0516
     wavelength: 0.011
+    use-antispiral-phase-shifts: true
 
 writer:
     output-file: "Summed_Channels.root"

--- a/Source/SpectrumAnalysis/KTChannelAggregator.cc
+++ b/Source/SpectrumAnalysis/KTChannelAggregator.cc
@@ -23,7 +23,9 @@ namespace Katydid
             fActiveRadius(0.0516),
             fNGrid(30),
             fWavelength(0.0115),
-            fIsGridDefined(false)
+            fIsGridDefined(false),
+	    fUseAntiSpiralPhaseShifts(false),
+	    fAntiSpiralPhaseShifts()
     {
     }
 
@@ -38,6 +40,7 @@ namespace Katydid
             fNGrid = node->get_value< signed int >("grid-size", fNGrid);
             fActiveRadius = node->get_value< double >("active-radius", fActiveRadius);
             fWavelength = node->get_value< double >("wavelength", fWavelength);
+            fUseAntiSpiralPhaseShifts = node->get_value< bool>("use-antispiral-phase-shifts", fUseAntiSpiralPhaseShifts);
         }
         return true;
     }
@@ -70,6 +73,21 @@ namespace Katydid
         return true;
     }
 
+    bool KTChannelAggregator::GenerateAntiSpiralPhaseShifts(int channelCount)
+    {
+	for(int i=0;i<channelCount;++i)
+	{
+	    double phaseShift=0.0;
+	    if(fUseAntiSpiralPhaseShifts) 
+	    {
+	        phaseShift=i*2*KTMath::Pi()/channelCount;
+	    }
+	    std::pair<int,double> channelPhaseShift=std::make_pair(i,phaseShift);
+	    fAntiSpiralPhaseShifts.insert(channelPhaseShift);
+	}
+	    return true;
+    }
+
     bool KTChannelAggregator::SumChannelVoltageWithPhase(KTFrequencySpectrumDataFFTW& fftwData)
     {
         const KTFrequencySpectrumFFTW* freqSpectrum = fftwData.GetSpectrumFFTW(0);
@@ -78,6 +96,7 @@ namespace Katydid
         int nFreqBins = freqSpectrum->GetNFrequencyBins();
         int nComponents = fftwData.GetNComponents(); // Get number of components
 
+	GenerateAntiSpiralPhaseShifts(nComponents);
         double maxValue = 0.0;
         double maxGridLocationX = 0.0;
         double maxGridLocationY = 0.0;
@@ -119,6 +138,11 @@ namespace Katydid
                 // Arbitarily assign 0 to the first channel and progresively add 2pi/N for the rest of the channels in increasing order
                 double channelAngle = 2 * KTMath::Pi() * iComponent / nComponents;
                 double phaseShift = GetPhaseShift(gridLocationX, gridLocationY, fWavelength, channelAngle);
+		// Just being redundantly cautious, the phaseShifts are already zerors but checking to make sure anyway
+		if(fUseAntiSpiralPhaseShifts)
+		{
+		    phaseShift+=fAntiSpiralPhaseShifts.at(iComponent);
+		}
                 // Get the frequency spectrum for that specific component
                 freqSpectrum = fftwData.GetSpectrumFFTW(iComponent);
                 double maxVoltage = 0.0;

--- a/Source/SpectrumAnalysis/KTChannelAggregator.cc
+++ b/Source/SpectrumAnalysis/KTChannelAggregator.cc
@@ -141,7 +141,7 @@ namespace Katydid
 		// Just being redundantly cautious, the phaseShifts are already zerors but checking to make sure anyway
 		if(fUseAntiSpiralPhaseShifts)
 		{
-		    phaseShift+=fAntiSpiralPhaseShifts.at(iComponent);
+		    phaseShift-=fAntiSpiralPhaseShifts.at(iComponent);
 		}
                 // Get the frequency spectrum for that specific component
                 freqSpectrum = fftwData.GetSpectrumFFTW(iComponent);

--- a/Source/SpectrumAnalysis/KTChannelAggregator.hh
+++ b/Source/SpectrumAnalysis/KTChannelAggregator.hh
@@ -42,6 +42,7 @@ namespace Katydid
      - "active-radius": double -- The active radius of the detection volume
      - "grid-size": signed int -- Size of the grid; If square grid is considered, the number of points in the grid is the square of grid-size
      - "wavelength": double -- Wavelength of the cyclotron motion
+     - "use-antispiral-phase-shifts": bool, -- A flad to indicate whether to use antispiral phase shifts
  
      Slots:
      - "fft": void (Nymph::KTDataPtr) -- Adds channels voltages using FFTW-phase information for appropriate phase addition; Requires KTFrequencySpectrumDataFFTW; Adds summation of the channel results; Emits signal "fft"
@@ -59,7 +60,6 @@ namespace Katydid
             bool Configure(const scarab::param_node* node);
 
             // in meters, should not be hard-coded
-            // PTS: Has to come as an input from config file ?
             MEMBERVARIABLE(double, ActiveRadius);
 
             // Get the grid size assuming a square grid
@@ -71,10 +71,17 @@ namespace Katydid
 
             //For exception handling to make sure the grid is defined before the spectra are assigned.
             MEMBERVARIABLE(bool, IsGridDefined);
+
+	    //AN electron undergoiing cyclotron motion has a spiral motion and not all receving channels are in phase.
+	    //If selected this option will make sure that there is a relative phase-shift applied 
+	    MEMBERVARIABLE(bool,UseAntiSpiralPhaseShifts);
         
             bool SumChannelVoltageWithPhase(KTFrequencySpectrumDataFFTW& fftwData);
 
         private:
+
+	    ///map that stores antispiral phase shifts
+	    std::map<int,double> fAntiSpiralPhaseShifts; 
 
             /// Returns the phase shift based on a given point, angle of the channel and the wavelength
             double GetPhaseShift(double xPosition, double yPosition, double wavelength, double channelAngle) const;
@@ -86,6 +93,9 @@ namespace Katydid
 
             /// Apply shift phase to the supplied points based on the phase provided
             bool ApplyPhaseShift(double &realVal, double &imagVal, double phase);
+	    
+	    /// Generate antispiral phase shifts and save in fAntiSpiralPhaseShifts vector to be applied to channels 
+	    bool GenerateAntiSpiralPhaseShifts(int channelCount);
 
             /// Convert frquency to wavlength
             double ConvertFrequencyToWavelength(double frequency);


### PR DESCRIPTION
A simple flag is added to the ChannelAggregator that introduces a 12 degree phase rotations to reconstruct an electron. This is critical to reconstruct a peak instead of a donut at the true electron position.