### PR TITLE
Hotfix to set the proper location and power of DBF grid point. 

### DIFF
--- a/Source/IO/BasicROOTFileWriter/KTBasicROOTTypeWriterSpectrumAnalysis.cc
+++ b/Source/IO/BasicROOTFileWriter/KTBasicROOTTypeWriterSpectrumAnalysis.cc
@@ -843,8 +843,11 @@ namespace Katydid
         unsigned nComponents = sumData.GetNComponents();
 
         if (! fWriter->OpenAndVerifyFile()) return;
+        unsigned optimizedGridIndex=sumData.GetOptimizedGridPoint();
+
         for (unsigned iChannel=0; iChannel<nComponents; iChannel++)
         {
+            if(iChannel!=optimizedGridIndex) continue;
             KTFrequencySpectrumFFTW* spectrum = sumData.GetSpectrumFFTW(iChannel);
             if (spectrum != NULL)
             {
@@ -899,9 +902,13 @@ namespace Katydid
         unsigned nComponents = sumData.GetNComponents();
 
         if (! fWriter->OpenAndVerifyFile()) return;
+        unsigned optimizedGridIndex=sumData.GetOptimizedGridPoint();
 
         for (unsigned iChannel=0; iChannel<nComponents; iChannel++)
         {
+            std::cout<< "::iChannel << <<optimizedGridIndex"<<std::endl;
+            std::cout<< iChannel << " : "<<optimizedGridIndex<<std::endl;
+            if(iChannel!=optimizedGridIndex) continue;
             KTPowerSpectrum* spectrum = sumData.GetSpectrum(iChannel);
             if (spectrum != NULL)
             {
@@ -935,7 +942,7 @@ namespace Katydid
         string graphName;
         conv >> graphName;
         std::vector<TGraph2D*> aggregatedGridGraphs = KT2ROOT::CreateGridGraphs(sumData,graphName);
-        for (int i=0;i<aggregatedGridGraphs.size();++i) 
+        for (unsigned i=0;i<aggregatedGridGraphs.size();++i) 
         {
             aggregatedGridGraphs.at(i)->SetDirectory(fWriter->GetFile());
             aggregatedGridGraphs.at(i)->Write();//Redundant
@@ -955,9 +962,13 @@ namespace Katydid
         unsigned nComponents = sumData.GetNComponents();
 
         if (! fWriter->OpenAndVerifyFile()) return;
+        unsigned optimizedGridIndex=sumData.GetOptimizedGridPoint();
 
         for (unsigned iChannel=0; iChannel<nComponents; iChannel++)
         {
+            std::cout<< "::iChannel << <<optimizedGridIndex"<<std::endl;
+            std::cout<< iChannel << " : "<<optimizedGridIndex<<std::endl;
+            if(iChannel!=optimizedGridIndex) continue;
             KTPowerSpectrum* spectrum = sumData.GetSpectrum(iChannel);
             if (spectrum != NULL)
             {

--- a/Source/IO/BasicROOTFileWriter/KTBasicROOTTypeWriterSpectrumAnalysis.cc
+++ b/Source/IO/BasicROOTFileWriter/KTBasicROOTTypeWriterSpectrumAnalysis.cc
@@ -906,8 +906,6 @@ namespace Katydid
 
         for (unsigned iChannel=0; iChannel<nComponents; iChannel++)
         {
-            std::cout<< "::iChannel << <<optimizedGridIndex"<<std::endl;
-            std::cout<< iChannel << " : "<<optimizedGridIndex<<std::endl;
             if(iChannel!=optimizedGridIndex) continue;
             KTPowerSpectrum* spectrum = sumData.GetSpectrum(iChannel);
             if (spectrum != NULL)
@@ -966,8 +964,6 @@ namespace Katydid
 
         for (unsigned iChannel=0; iChannel<nComponents; iChannel++)
         {
-            std::cout<< "::iChannel << <<optimizedGridIndex"<<std::endl;
-            std::cout<< iChannel << " : "<<optimizedGridIndex<<std::endl;
             if(iChannel!=optimizedGridIndex) continue;
             KTPowerSpectrum* spectrum = sumData.GetSpectrum(iChannel);
             if (spectrum != NULL)

--- a/Source/SpectrumAnalysis/KTAggregatedChannelOptimizer.cc
+++ b/Source/SpectrumAnalysis/KTAggregatedChannelOptimizer.cc
@@ -37,10 +37,10 @@ namespace Katydid
     {
         const KTFrequencySpectrumFFTW* freqSpectrum=aggData.GetSpectrumFFTW(0);
         // Get the number of frequency bins from the first component of aggData
-        int nFreqBins=freqSpectrum->GetNFrequencyBins();
-        int nGridPoints=aggData.GetNComponents(); // Get number of components
+        unsigned nFreqBins=freqSpectrum->GetNFrequencyBins();
+        unsigned nGridPoints=aggData.GetNComponents(); // Get number of components
         
-        int maxGridPoint=0.0;
+        unsigned maxGridPoint=0;
         double maxVoltage=0.0;
         // Loop over each component and find and save the maximum summed absolute voltages and the corresponding frequencies
         for (unsigned iGridPoint=0; iGridPoint<nGridPoints; ++iGridPoint)

--- a/Source/Transform/KTConvertToPower.cc
+++ b/Source/Transform/KTConvertToPower.cc
@@ -123,6 +123,7 @@ namespace Katydid
             psData.SetGridPoint(iComponent,gridLocationX,gridLocationY,gridLocationZ);
             psData.SetSummedGridPower(iComponent,*(std::max_element(spectrum->begin(), spectrum->end())));
         }
+        psData.SetOptimizedGridPointValue(data.GetOptimizedGridPoint(),data.GetOptimizedGridValue());
         return true;
     }
     
@@ -143,6 +144,7 @@ namespace Katydid
             psData.SetGridPoint(iComponent,gridLocationX,gridLocationY,gridLocationZ);
             psData.SetSummedGridPower(iComponent,*(std::max_element(spectrum->begin(), spectrum->end())));
         }
+        psData.SetOptimizedGridPointValue(data.GetOptimizedGridPoint(),data.GetOptimizedGridValue());
         return true;
     }
 


### PR DESCRIPTION
Set the proper location of optimized grid point correctly for aggregated power and PSD. This was previously only done for frequency spectrum and had to be explicitly added to the aggregated power and PSD cases as well. 